### PR TITLE
feat(csharp): first C# generator implementation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,13 +2,15 @@
 
 import { Command } from 'commander';
 import { TypeScriptGenerator } from './generators/typescript';
+import { CSharpGenerator } from './generators/csharp';
 import { SchemaLoader } from './loader';
 import path from 'path';
 import fs from 'fs';
 
 
 const generators = {
-  typescript: TypeScriptGenerator
+  typescript: TypeScriptGenerator,
+  csharp: CSharpGenerator
 }
 
 const program = new Command();
@@ -54,22 +56,34 @@ program.command('generate')
       fs.mkdirSync(outputDir, { recursive: true });
     }
 
+    let generator;
     switch (options.generator) {
-          case 'typescript':
-              const generator = new generators.typescript({
-                  outputDir,
-                  loaderOptions: {
-                    packages: options.package.split(',').map((pkg: string) => pkg.trim())
-                  },
-                  generateClasses: options.generateClasses
-              });
-              await generator.init();
-              await generator.generate();
-              break;
-          default:
-              console.error(`Unknown generator: ${options.generator}`);
-              process.exit(1);
-      }
+      case "typescript":
+        generator = new generators.typescript({
+          outputDir,
+          loaderOptions: {
+            packages: options.package.split(",").map((pkg: string) => pkg.trim()),
+          },
+          generateClasses: options.generateClasses,
+        });
+        await generator.init();
+        await generator.generate();
+        break;
+      case "csharp":
+        generator = new generators.csharp({
+          outputDir,
+          loaderOptions: {
+            packages: options.package.split(",").map((pkg: string) => pkg.trim()),
+          },
+          generateClasses: options.generateClasses,
+        });
+        await generator.init();
+        await generator.generate();
+        break;
+      default:
+        console.error(`Unknown generator: ${options.generator}`);
+        process.exit(1);
+    }
   });
 
 program.parse();

--- a/src/generators/csharp.ts
+++ b/src/generators/csharp.ts
@@ -1,0 +1,126 @@
+import { Generator, GeneratorOptions } from "../generator";
+import { TypeRef, TypeSchema } from "../typeschema";
+
+export interface CSharpScriptGeneratorOptions extends GeneratorOptions {
+    generateClasses?: boolean;
+}
+
+const typeMap :  Record<string, string> = {
+    boolean: "bool",
+    instant: "string",
+    time: "string",
+    date: "string",
+    dateTime: "string",
+        
+    decimal: "decimal",
+    integer: "int",
+    unsignedInt: "long",
+    positiveInt: "long",
+    integer64: "long",
+    base64Binary: "string",
+        
+    uri: "string",
+    url: "string",
+    canonical: "string",
+    oid: "string",
+    uuid: "string",
+        
+    string: "string",
+    code: "string",
+    markdown: "string",
+    id: "string",
+    xhtml: "string",
+}
+
+export class CSharpGenerator extends Generator {
+    constructor(opts: CSharpScriptGeneratorOptions) {
+        super(opts);
+    }
+
+    toLangType(fhirType: TypeRef) {
+        return typeMap[fhirType.name] ?? fhirType.name;
+    }
+
+    lineSM(...tokens: string[]) {
+        this.writeIdent();
+        this.write(tokens.filter(Boolean).join(' ') + ';\n');
+    }
+
+    curlyBlock(tokens: string[], gencontent: () => void) {
+        this.write(tokens.join(' '));
+        this.write('\n{\n');
+        this.ident();
+        gencontent();
+        this.deident();
+        this.write('}\n');
+    }
+
+    pascalCase(s: string) {
+        // we expect that `s` arg is always in camelCase
+        return [s[0].toUpperCase(), ...s.slice(1)].join('');
+    }
+
+    generateType(schema: TypeSchema) {
+        let base = schema.base ? ': ' + schema.base.name : '';
+        this.curlyBlock(['public', 'class', schema.name.name, base], () => {
+            if (schema.fields) {
+                for (const [fieldName, field] of Object.entries(schema.fields).sort((a, b) => a[0].localeCompare(b[0]))) {
+                    // questionable
+                    const baseNamespacePrefix = field.type.type == 'complex-type' ? 'Base.' : '';
+
+                    const nullable = field.required ? '' : '?';
+                    const required = field.required ? 'required' : '';
+                    const arraySpecifier = field.array ? '[]' : '';
+                    const accessors = "{ get; set; }";
+                    
+                    const fieldType = baseNamespacePrefix + this.toLangType(field.type) + arraySpecifier + nullable;
+                    const fieldSymbol = this.pascalCase(fieldName);
+
+                    this.lineSM('public', required, fieldType, fieldSymbol, accessors);
+                }
+            }
+
+            if (schema.nestedTypes) {
+                this.line()
+                this.ident();
+                for (let subtype of schema.nestedTypes) {
+                    this.generateType(subtype);
+                }
+                this.deident();
+            }
+        });
+        this.line();
+    }
+
+    generate() {
+        this.dir('src', async () => {
+            this.file('base.cs', () => {
+                this.lineSM('namespace', 'Aidbox.FHIR.BAse');
+
+                for (let schema of this.loader.complexTypes()) {
+                    this.generateType(schema);
+                }
+            });
+
+            for (let schema of this.loader.resources()) {
+                this.file(schema.name.name + ".cs", () => {
+                    if (schema.allDependencies) {
+                        if (schema.allDependencies.filter(d => d.type == 'complex-type').length) {
+                            this.lineSM('using', 'Aidbox.FHIR.Base');
+                        }
+                        
+                        if (schema.allDependencies.filter(d => d.type == 'resource').length) {
+                            this.lineSM('using', 'Aidbox.FHIR.R4.Core');
+                        }
+                    }
+
+                    this.line();
+                    this.lineSM('namespace', 'Aidbox.FHIR.R4.Core');
+                    this.line();
+
+                    this.generateType(schema);
+                });
+            }
+        })
+    }
+}   


### PR DESCRIPTION
Here is my draft C# generator implementation.

I understand the work on `TypeSchema` all the core stuff part might still be in progress, but I wanted to share my findings while attempting to generate C# code. 

- [ ] The `curlyBlock` helper should support generating opening brackets on the next line based on language conventions.
- [ ] Maybe consider introducing a more abstract `block` helper that adapts its behavior to the target language? For instance:
  - For Python, no curly bracase are needed.
  - For Ruby, blocks should conclude with the `end` keyword.
- [ ] Add functionality to filter out empty strings in the `lineSM` helper.
- [ ] There is no straightforward way to generate inner classes, particularly for C#. 
While I can work around limitation, proper indentation in the `curlyBlock`  is challenging.
- [ ] As I can see, currently, there are no constrained resources.
- [ ] Provide a way to organize generated resources into namespace or packages that align with FHIR packages 
- [ ] There is no way to pack generated resources into different namespaces/packages according to FHIR packages. For instance:
  - Place  `h7.fhir.us.core` resources into  `hl7-fhir-us-core` directory.
  - Place  `hl7.fhir.r4b.core` resources into `hl7-fhir-r4b-core` directory.
  - So the final result will be something like this:

    ```
    - types
      - hl7-fhir-r4b-core
        - Account.ts
        -…
      - hl7-fhir-us-core
        - UsCoreBodyHeight.ts
        - …
    - api.ts
    ```

  